### PR TITLE
feat(jsonpath-plus): Updated to 7.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "husky": "^4.3.8",
         "json-schema-faker": "^0.5.0-rcv.39",
         "jsonpath": "^1.1.1",
-        "jsonpath-plus": "^6.0.1",
+        "jsonpath-plus": "^7.1.0",
         "karma": "^6.3.5",
         "karma-chrome-launcher": "^3.1.0",
         "karma-firefox-launcher": "^2.1.1",
@@ -55,7 +55,7 @@
         "node": ">=14.13"
       },
       "optionalDependencies": {
-        "jsonpath-plus": "^6.0.1",
+        "jsonpath-plus": "^7.1.0",
         "lodash.topath": "^4.5.2"
       }
     },
@@ -4912,12 +4912,12 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz",
-      "integrity": "sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.1.0.tgz",
+      "integrity": "sha512-gTaNRsPWO/K2KY6MrqaUFClF9kmuM6MFH5Dhg1VYDODgFbByw1yb7xu3hrViE/sz+dGOeMWgCzwUwQtAnCTE9g==",
       "dev": true,
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/jsonpath/node_modules/esprima": {
@@ -11420,9 +11420,9 @@
       }
     },
     "jsonpath-plus": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz",
-      "integrity": "sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.1.0.tgz",
+      "integrity": "sha512-gTaNRsPWO/K2KY6MrqaUFClF9kmuM6MFH5Dhg1VYDODgFbByw1yb7xu3hrViE/sz+dGOeMWgCzwUwQtAnCTE9g==",
       "dev": true
     },
     "junk": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "husky": "^4.3.8",
     "json-schema-faker": "^0.5.0-rcv.39",
     "jsonpath": "^1.1.1",
-    "jsonpath-plus": "^6.0.1",
+    "jsonpath-plus": "^7.1.0",
     "karma": "^6.3.5",
     "karma-chrome-launcher": "^3.1.0",
     "karma-firefox-launcher": "^2.1.1",
@@ -99,7 +99,7 @@
     "rollup": "^2.56.2"
   },
   "optionalDependencies": {
-    "jsonpath-plus": "^6.0.1",
+    "jsonpath-plus": "^7.1.0",
     "lodash.topath": "^4.5.2"
   },
   "dependencies": {


### PR DESCRIPTION
Updated the version of jsonpath-plus to 7.1.0 to benefit from performance upgrades in JSONPath library. Just take a look at this pull request: https://github.com/JSONPath-Plus/JSONPath/pull/175 => You can see time reduction up to 50%, I personally even reached reduction up to 75%.

Would be great if could just release a new version on NPM with this change. Thanks :) 